### PR TITLE
Add search logic for songs and playlists

### DIFF
--- a/simple_music_service/views.py
+++ b/simple_music_service/views.py
@@ -2,6 +2,7 @@ from rest_framework import viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework_simplejwt.views import TokenObtainPairView
 from rest_framework.response import Response
+from rest_framework.filters import SearchFilter
 from django.shortcuts import get_object_or_404
 from django.contrib.auth.models import User
 from .serializers import (
@@ -19,11 +20,12 @@ class SongViewSet(viewsets.ModelViewSet):
     queryset = Song.objects.all()
     serializer_class = SongSerializer
     http_method_names = ["get"]
+    filter_backends = [SearchFilter]
+    search_fields = ["title", "artist__name"]
 
 
-class NestedSongViewSet(viewsets.ModelViewSet):
-    queryset = Song.objects.all()
-    serializer_class = SongSerializer
+class NestedSongViewSet(SongViewSet):
+    http_method_names = ["get", "post", "delete"]
 
     def get_queryset(self):
         return Song.objects.filter(user=self.kwargs["users_pk"])
@@ -53,12 +55,15 @@ class SignupViewSet(viewsets.ModelViewSet):
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
+    http_method_names = []
 
 
 class PlaylistViewSet(viewsets.ModelViewSet):
     queryset = Playlist.objects.all()
     serializer_class = PlaylistSerializer
     permission_classes = (IsOwner,)
+    filter_backends = [SearchFilter]
+    search_fields = ["^title"]
 
     def get_queryset(self):
         return Playlist.objects.filter(user=self.kwargs["users_pk"])


### PR DESCRIPTION
**Task:** Implement the ability to search playlists by title and search songs by title or artist name.

**Solution steps:**
1. Add logic to search songs by partial title match or partial artist name match.
2. Add logic to search playlists whose title starts with a search parameter.