### PR TITLE
Add sort and pagination logic for songs and playlists

### DIFF
--- a/simple_music_service/paginations.py
+++ b/simple_music_service/paginations.py
@@ -1,0 +1,6 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class PageNumberAndPageSizePagination(PageNumberPagination):
+    page_size_query_param = "page_size"
+    max_page_size = 100

--- a/simple_music_service/tests.py
+++ b/simple_music_service/tests.py
@@ -164,17 +164,18 @@ class SongViewSetTest(APITestCase):
             self.assertIn(SongSerializer(instance=song).data, response.data)
 
     def test_can_search_songs_by_title_or_artist_name(self):
-        search_string = "title"
-        response = self.client.get(reverse("song-list"), {"search": search_string})
+        search_params = ["title", "test title", "artist name", "song artist"]
+        for search_string in search_params:
+            with self.subTest(search_string=search_string):
+                response = self.client.get(reverse("song-list"), {"search": search_string})
 
-        searched_songs = list(
-            filter(lambda song: search_string in song.title or search_string in self.get_artist_name(song), self.songs)
-        )
+                searched_songs = [song for song in self.songs
+                                  if search_string in song.title or search_string in self.get_artist_name(song)]
 
-        self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(len(searched_songs), len(response.data))
-        for song in searched_songs:
-            self.assertIn(SongSerializer(instance=song).data, response.data)
+                self.assertEqual(status.HTTP_200_OK, response.status_code)
+                self.assertEqual(len(searched_songs), len(response.data))
+                for song in searched_songs:
+                    self.assertIn(SongSerializer(instance=song).data, response.data)
 
     @staticmethod
     def get_artist_name(song):
@@ -313,15 +314,18 @@ class PlaylistViewSetTest(APITestCase):
     def test_can_search_playlist_by_title(self):
         authorization(self.client, self.user)
 
-        search_title = "playlist"
-        response = self.client.get(reverse("playlist-list", args=[self.user.id]), {"search": search_title})
+        search_params = ["playlist", "title", "test title"]
+        for search_title in search_params:
+            with self.subTest(search_params=search_params):
+                response = self.client.get(reverse("playlist-list", args=[self.user.id]), {"search": search_title})
 
-        search_playlists = list(filter(lambda playlist: playlist.title.startswith(search_title), self.user_playlists))
+                search_playlists = [playlist for playlist in self.user_playlists
+                                    if playlist.title.startswith(search_title)]
 
-        self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(len(search_playlists), len(response.data))
-        for playlist in search_playlists:
-            self.assertIn(PlaylistSerializer(instance=playlist).data, response.data)
+                self.assertEqual(status.HTTP_200_OK, response.status_code)
+                self.assertEqual(len(search_playlists), len(response.data))
+                for playlist in search_playlists:
+                    self.assertIn(PlaylistSerializer(instance=playlist).data, response.data)
 
     def test_can_sorting_playlists(self):
         sorting_params = {

--- a/simple_music_service/views.py
+++ b/simple_music_service/views.py
@@ -2,7 +2,7 @@ from rest_framework import viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework_simplejwt.views import TokenObtainPairView
 from rest_framework.response import Response
-from rest_framework.filters import SearchFilter
+from rest_framework.filters import SearchFilter, OrderingFilter
 from django.shortcuts import get_object_or_404
 from django.contrib.auth.models import User
 from .serializers import (
@@ -20,8 +20,10 @@ class SongViewSet(viewsets.ModelViewSet):
     queryset = Song.objects.all()
     serializer_class = SongSerializer
     http_method_names = ["get"]
-    filter_backends = [SearchFilter]
+    filter_backends = [SearchFilter, OrderingFilter]
     search_fields = ["title", "artist__name"]
+    ordering_fields = ["title", "year"]
+    ordering = ["-year"]
 
 
 class NestedSongViewSet(SongViewSet):
@@ -62,8 +64,10 @@ class PlaylistViewSet(viewsets.ModelViewSet):
     queryset = Playlist.objects.all()
     serializer_class = PlaylistSerializer
     permission_classes = (IsOwner,)
-    filter_backends = [SearchFilter]
+    filter_backends = [SearchFilter, OrderingFilter]
     search_fields = ["^title"]
+    ordering_fields = ["title"]
+    ordering = ["title"]
 
     def get_queryset(self):
         return Playlist.objects.filter(user=self.kwargs["users_pk"])

--- a/simple_music_service/views.py
+++ b/simple_music_service/views.py
@@ -14,6 +14,7 @@ from .serializers import (
 )
 from .models import Song, Artist, Playlist
 from .permissions import IsOwner
+from .paginations import PageNumberAndPageSizePagination
 
 
 class SongViewSet(viewsets.ModelViewSet):
@@ -21,6 +22,7 @@ class SongViewSet(viewsets.ModelViewSet):
     serializer_class = SongSerializer
     http_method_names = ["get"]
     filter_backends = [SearchFilter, OrderingFilter]
+    pagination_class = PageNumberAndPageSizePagination
     search_fields = ["title", "artist__name"]
     ordering_fields = ["title", "year"]
     ordering = ["-year"]
@@ -65,6 +67,7 @@ class PlaylistViewSet(viewsets.ModelViewSet):
     serializer_class = PlaylistSerializer
     permission_classes = (IsOwner,)
     filter_backends = [SearchFilter, OrderingFilter]
+    pagination_class = PageNumberAndPageSizePagination
     search_fields = ["^title"]
     ordering_fields = ["title"]
     ordering = ["title"]


### PR DESCRIPTION
**Tasks:** 
1. Implement the ability to sort songs and playlists.
2. Implement the ability to paginate songs and playlists.

**Solution steps:**
1. Add logic to sort songs by title and release date and set the default sort by release date from newest to oldest.
2. Add logic to sort playlists by title and set the default sort by title from A to Z.
3. Add logic to paginate songs and playlists using page number and page size.
4. Write tests to sort and paginate songs and playlists.
5. Update tests to search songs and playlists with variations of search parameters.
